### PR TITLE
Allow build-level overrides for Campfire subdomain and token

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -24,6 +24,7 @@ Other features have since been added including...
 * Play sounds on build success and failure, added by Henry Poydar.
 * Build notifications now include commit info.
 * Room to which notifications are sent can be customised per-project.
+* Subdomain and API token can be customized per-project.
 
 Note: The plugin code is a bit of a mess, partly just because I don't have a
 lot of Java experience, but also because I simply haven't got the time to tidy

--- a/src/main/java/hudson/plugins/campfire/Campfire.java
+++ b/src/main/java/hudson/plugins/campfire/Campfire.java
@@ -51,6 +51,14 @@ public class Campfire {
       return this.subdomain + ".campfirenow.com";
     }
 
+    public String getSubdomain() {
+      return this.subdomain;
+    }
+
+    public String getToken() {
+      return this.token;
+    }
+
     protected String getProtocol() {
       if (this.ssl) { return "https://"; }
       return "http://";

--- a/src/main/java/hudson/plugins/campfire/CampfireNotifier.java
+++ b/src/main/java/hudson/plugins/campfire/CampfireNotifier.java
@@ -19,19 +19,35 @@ import java.util.logging.Logger;
 
 public class CampfireNotifier extends Notifier {
 
-    private transient Campfire campfire;
+    private Campfire campfire;
     private Room room;
     private String hudsonUrl;
     private boolean smartNotify;
     private boolean sound;
 
-    // getter for project configuration..
-    // Configured room name should be null unless different from descriptor/global room name
+    // getters for project configuration..
+    // Configured room name / subdomain / token should be null unless different from descriptor/global values
     public String getConfiguredRoomName() {
         if ( DESCRIPTOR.getRoom().equals(room.getName()) ) {
             return null;
         } else {
             return room.getName();
+        }
+    }
+
+    public String getConfiguredSubdomain() {
+        if ( DESCRIPTOR.getSubdomain().equals(campfire.getSubdomain()) ) {
+            return null;
+        } else {
+            return campfire.getSubdomain();
+        }
+    }
+
+    public String getConfiguredToken() {
+        if ( DESCRIPTOR.getToken().equals(campfire.getToken()) ) {
+            return null;
+        } else {
+            return campfire.getToken();
         }
     }
 

--- a/src/main/java/hudson/plugins/campfire/DescriptorImpl.java
+++ b/src/main/java/hudson/plugins/campfire/DescriptorImpl.java
@@ -48,7 +48,7 @@ public class DescriptorImpl extends BuildStepDescriptor<Publisher> {
     public boolean getSsl() {
         return ssl;
     }
-    
+
     public boolean getSmartNotify() {
         return smartNotify;
     }
@@ -67,11 +67,19 @@ public class DescriptorImpl extends BuildStepDescriptor<Publisher> {
     @Override
     public Publisher newInstance(StaplerRequest req, JSONObject formData) throws FormException {
         String projectRoom = req.getParameter("roomName");
+        String projectToken = req.getParameter("cfToken");
+        String projectSubdomain = req.getParameter("cfSubdomain");
         if ( projectRoom == null || projectRoom.trim().length() == 0 ) {
             projectRoom = room;
         }
+        if ( projectToken == null || projectToken.trim().length() == 0 ) {
+            projectToken = token;
+        }
+        if ( projectSubdomain == null || projectSubdomain.trim().length() == 0 ) {
+            projectSubdomain = subdomain;
+        }
         try {
-            return new CampfireNotifier(subdomain, token, projectRoom, hudsonUrl, ssl, smartNotify, sound);
+            return new CampfireNotifier(projectSubdomain, projectToken, projectRoom, hudsonUrl, ssl, smartNotify, sound);
         } catch (Exception e) {
             String message = "Failed to initialize campfire notifier - check your campfire notifier configuration settings: " + e.getMessage();
             LOGGER.log(Level.WARNING, message, e);

--- a/src/main/java/hudson/plugins/campfire/DescriptorImpl.java
+++ b/src/main/java/hudson/plugins/campfire/DescriptorImpl.java
@@ -66,9 +66,9 @@ public class DescriptorImpl extends BuildStepDescriptor<Publisher> {
      */
     @Override
     public Publisher newInstance(StaplerRequest req, JSONObject formData) throws FormException {
-        String projectRoom = req.getParameter("roomName");
-        String projectToken = req.getParameter("cfToken");
-        String projectSubdomain = req.getParameter("cfSubdomain");
+        String projectSubdomain = req.getParameter("campfireSubdomain");
+        String projectToken = req.getParameter("campfireToken");
+        String projectRoom = req.getParameter("campfireRoom");
         if ( projectRoom == null || projectRoom.trim().length() == 0 ) {
             projectRoom = room;
         }

--- a/src/main/java/hudson/plugins/campfire/Room.java
+++ b/src/main/java/hudson/plugins/campfire/Room.java
@@ -6,7 +6,7 @@ import java.util.Map;
 import java.util.Date;
 
 public class Room {
-    private transient Campfire campfire;
+    private Campfire campfire;
     private String name;
     private String id;
 

--- a/src/main/resources/hudson/plugins/campfire/CampfireNotifier/config.jelly
+++ b/src/main/resources/hudson/plugins/campfire/CampfireNotifier/config.jelly
@@ -3,6 +3,14 @@
     This jelly script is used for per-project configuration.
     See global.jelly for a general discussion about jelly script.
   -->
+    <f:entry title="Project Subdomain" description="Optional. Use to send notifications to a subdomain other than the default (${descriptor.getSubdomain()})" help="${rootURL}/plugin/campfire/help-projectConfig-subdomain.html">
+      <f:textbox name="cfSubdomain" value="${instance.getConfiguredSubdomain()}"/>
+    </f:entry>
+
+    <f:entry title="Project API Token" description="Optional. Use to send notifications to an API token other than the default (${descriptor.getToken()})" help="${rootURL}/plugin/campfire/help-projectConfig-token.html">
+      <f:textbox name="cfToken" value="${instance.getConfiguredToken()}"/>
+    </f:entry>
+
     <f:entry title="Project Room Name" description="Optional. Use to send notifications to a room other than the default (${descriptor.getRoom()})" help="${rootURL}/plugin/campfire/help-projectConfig-room.html">
       <f:textbox name="roomName" value="${instance.getConfiguredRoomName()}"/>
     </f:entry>

--- a/src/main/resources/hudson/plugins/campfire/CampfireNotifier/config.jelly
+++ b/src/main/resources/hudson/plugins/campfire/CampfireNotifier/config.jelly
@@ -4,14 +4,12 @@
     See global.jelly for a general discussion about jelly script.
   -->
     <f:entry title="Project Subdomain" description="Optional. Use to send notifications to a subdomain other than the default (${descriptor.getSubdomain()})" help="${rootURL}/plugin/campfire/help-projectConfig-subdomain.html">
-      <f:textbox name="cfSubdomain" value="${instance.getConfiguredSubdomain()}"/>
+      <f:textbox name="campfireSubdomain" value="${instance.getConfiguredSubdomain()}"/>
     </f:entry>
-
     <f:entry title="Project API Token" description="Optional. Use to send notifications to an API token other than the default (${descriptor.getToken()})" help="${rootURL}/plugin/campfire/help-projectConfig-token.html">
-      <f:textbox name="cfToken" value="${instance.getConfiguredToken()}"/>
+      <f:textbox name="campfireToken" value="${instance.getConfiguredToken()}"/>
     </f:entry>
-
     <f:entry title="Project Room Name" description="Optional. Use to send notifications to a room other than the default (${descriptor.getRoom()})" help="${rootURL}/plugin/campfire/help-projectConfig-room.html">
-      <f:textbox name="roomName" value="${instance.getConfiguredRoomName()}"/>
+      <f:textbox name="campfireRoom" value="${instance.getConfiguredRoomName()}"/>
     </f:entry>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/campfire/CampfireNotifier/global.jelly
+++ b/src/main/resources/hudson/plugins/campfire/CampfireNotifier/global.jelly
@@ -12,10 +12,10 @@
     so it should be straightforward to find them.
   -->
 <f:section title="Global Campfire Notifier Settings">
-    <f:entry title="Subdomain" help="${rootURL}/plugin/campfire/help-globalConfig-subdomain.html">
+    <f:entry title="Default Subdomain" help="${rootURL}/plugin/campfire/help-globalConfig-subdomain.html">
         <f:textbox name="campfireSubdomain" value="${descriptor.getSubdomain()}" />
     </f:entry>
-    <f:entry title="API Token" help="${rootURL}/plugin/campfire/help-globalConfig-token.html">
+    <f:entry title="Default API Token" help="${rootURL}/plugin/campfire/help-globalConfig-token.html">
         <f:textbox name="campfireToken" value="${descriptor.getToken()}" />
     </f:entry>
     <f:entry title="Default Room Name" help="${rootURL}/plugin/campfire/help-globalConfig-room.html">

--- a/src/main/webapp/help-projectConfig-subdomain.html
+++ b/src/main/webapp/help-projectConfig-subdomain.html
@@ -1,0 +1,3 @@
+<div>
+  <p>The subdomain for your Campfire account , if different from the default subdomain configuration in the global campfire notifier settings.
+</div>

--- a/src/main/webapp/help-projectConfig-token.html
+++ b/src/main/webapp/help-projectConfig-token.html
@@ -1,0 +1,3 @@
+<div>
+  <p>The API authentication token that should be used to send notifications for this project, if different from the default token configuration in the global campfire notifier settings.</p>
+</div>


### PR DESCRIPTION
We run a consultancy, so we have a Jenkins server that needs to notify Campfire rooms for multiple organizations. This change allows the user to customize the API token and subdomain on a per-project basis to override global defaults.
