### PR TITLE
Use the full project name instead of the short one

### DIFF
--- a/src/main/java/hudson/plugins/campfire/CampfireNotifier.java
+++ b/src/main/java/hudson/plugins/campfire/CampfireNotifier.java
@@ -114,7 +114,7 @@ public class CampfireNotifier extends Notifier {
         }
         String resultString = result.toString();
         if (!smartNotify && result == Result.SUCCESS) resultString = resultString.toLowerCase();
-        String message = build.getProject().getName() + " " + build.getDisplayName() + " \"" + changeString + "\": " + resultString;
+        String message = build.getProject().getFullName() + " " + build.getDisplayName() + " \"" + changeString + "\": " + resultString;
         if (hudsonUrl != null && hudsonUrl.length() > 1 && (smartNotify || result != Result.SUCCESS)) {
             message = message + " (" + hudsonUrl + build.getUrl() + ")";
         }


### PR DESCRIPTION
- This matters for multi-configuration projects since the short project
  name ends up being something like "api=5,keys=no", which isn't very
  useful. Instead, it will output something like
  "android/api=5,keys=no".
