### PR TITLE
[needs work] allow message to be configured

### DIFF
--- a/src/main/java/hudson/plugins/campfire/CampfireNotifier.java
+++ b/src/main/java/hudson/plugins/campfire/CampfireNotifier.java
@@ -9,6 +9,8 @@ import hudson.scm.ChangeLogSet;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Notifier;
 
+import org.kohsuke.stapler.DataBoundConstructor;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
@@ -72,6 +74,7 @@ public class CampfireNotifier extends Notifier {
         initialize();
     }
 
+    @DataBoundConstructor
     public CampfireNotifier(String subdomain, String token, String room, String hudsonUrl, String notificationTemplate,
                             boolean ssl, boolean smartNotify, boolean sound) {
         super();

--- a/src/main/resources/hudson/plugins/campfire/CampfireNotifier/config.jelly
+++ b/src/main/resources/hudson/plugins/campfire/CampfireNotifier/config.jelly
@@ -12,4 +12,9 @@
     <f:entry title="Project Room Name" description="Optional. Use to send notifications to a room other than the default (${descriptor.getRoom()})" help="${rootURL}/plugin/campfire/help-projectConfig-room.html">
       <f:textbox name="campfireRoom" value="${instance.getConfiguredRoomName()}"/>
     </f:entry>
+    <f:entry title="Project Notification Message Template" description="Optional. Override the message sent to the Campfire room other than the default (${descriptor.getNotificationTemplate()})."
+      help="${rootURL}/plugin/campfire/help-projectConfig-notificationTemplate.html">
+      <f:textbox name="campfireNotificationTemplate" value="${instance.getConfiguredNotificationTemplate()}" />
+    </f:entry>
+
 </j:jelly>

--- a/src/main/resources/hudson/plugins/campfire/CampfireNotifier/global.jelly
+++ b/src/main/resources/hudson/plugins/campfire/CampfireNotifier/global.jelly
@@ -24,6 +24,9 @@
     <f:entry title="Hudson Url" help="${rootURL}/plugin/campfire/help-globalConfig-hudsonUrl.html">
         <f:textbox name="campfireHudsonUrl" value="${descriptor.getHudsonUrl()}" />
     </f:entry>
+    <f:entry title="Notification Message Template" help="${rootURL}/plugin/campfire/help-globalConfig-notificationTemplate.html">
+        <f:textbox name="campfireNotificationTemplate" value="${descriptor.getNotificationTemplate()}" default="${descriptor.defaultNotificationTemplate}" />
+    </f:entry>
     <f:entry title="SSL" help="${rootURL}/plugin/campfire/help-globalConfig-ssl.html">
         <f:checkbox name="campfireSsl" checked="${descriptor.getSsl()}" />
     </f:entry>

--- a/src/main/webapp/help-globalConfig-notificationTemplate.html
+++ b/src/main/webapp/help-globalConfig-notificationTemplate.html
@@ -1,0 +1,14 @@
+<div>
+  <p>Optionally specify the template used to construct the notifications sent to the Campfire room.</p>
+  <p>Supported replacements:</p>
+  <ul>
+    <li>%PROJECT_NAME% -- Name of the Jenkins project</li>
+    <li>%BUILD_DISPLAY_NAME% -- Display name for a particular build</li>
+    <li>%RESULT% -- Result of a particular build (capitalized)</li>
+    <li>%SMART_RESULT% -- Result of a particular build (capitalized except for "success")</li>
+    <li>%CHANGES% -- Brief description of the changes in the build</li>
+    <li>%BUILD_URL% -- URL for a particular build</li>
+    <li>%% -- Bare % character</li>
+  </ul>
+  <p>Default: %PROJECT_NAME% %BUILD_DISPLAY_NAME% (%CHANGES%): %SMART_RESULT% (%BUILD_URL%)</p>
+</div>

--- a/src/main/webapp/help-projectConfig-notificationTemplate.html
+++ b/src/main/webapp/help-projectConfig-notificationTemplate.html
@@ -1,0 +1,15 @@
+<div>
+  <p>Optionally specify the template used to construct the notifications sent to the Campfire room, if
+      different than the global notification template.</p>
+  <p>Supported replacements:</p>
+  <ul>
+    <li>%PROJECT_NAME% -- Name of the Jenkins project</li>
+    <li>%BUILD_DISPLAY_NAME% -- Display name for a particular build</li>
+    <li>%RESULT% -- Result of a particular build (capitalized)</li>
+    <li>%SMART_RESULT% -- Result of a particular build (capitalized except for "success")</li>
+    <li>%CHANGES% -- Brief description of the changes in the build</li>
+    <li>%BUILD_URL% -- URL for a particular build</li>
+    <li>%% -- Bare % character</li>
+  </ul>
+  <p>Default: %PROJECT_NAME% %BUILD_DISPLAY_NAME% (%CHANGES%): %SMART_RESULT% (%BUILD_URL%)</p>
+</div>


### PR DESCRIPTION
DO NOT ACTUALLY COMMIT THIS YET!

I created this pull request to obtain some code review comments. This has a bug where CampfireNotifier thinks that notificationTemplate is the empty string. Yet, the config screen for the project sees the descriptor.

When I set the notificationTemplate in the per-project settings, the changes work correctly.

Jenkins config system is confusing. Thoughts?
